### PR TITLE
Uncomments structure for defaults

### DIFF
--- a/_color.scss
+++ b/_color.scss
@@ -4,13 +4,13 @@
 /*
   Utility that automatically generates all of the color styles
   for a project. Relies on a $colors map variable existing in the following format:
-
-  $colors: (
-    black: #222,
-    white: #fff,
-    gray: #aaa
-  );
 */
+
+$colors: (
+  black: #222,
+  white: #fff,
+  gray: #aaa
+) !default;
 
 //---------------------------------------------------------------
 // Variables

--- a/_spacing.scss
+++ b/_spacing.scss
@@ -7,18 +7,18 @@
   Mixin to provide spacing (either margin or padding) to a defined
   location of an element and have that spacing scale down proportionally
   at smaller screen sizes. Relies on a $spacing map variable existing in the following format:
-
-  $spacing: (
-    none: 0,
-    xs: 2rem,
-    s: 3rem,
-    sm: 4rem,
-    m: 5rem,
-    ml: 6rem,
-    l: 8.5rem,
-    xl: 15rem
-  );
 */
+
+$spacing: (
+  none: 0,
+  xs: 2rem,
+  s: 3rem,
+  sm: 4rem,
+  m: 5rem,
+  ml: 6rem,
+  l: 8.5rem,
+  xl: 15rem
+) !default;
 
 
 //---------------------------------------------------------------

--- a/_type-styles.scss
+++ b/_type-styles.scss
@@ -7,44 +7,44 @@
 /*
   Utility that automatically generates all of the type styles
   for a project. Relies on $type-styles and $font-stacks map variables existing in the following format:
-
-  $font-stacks: (
-    futura-bold: (
-      font-family: (Futura, 'Trebuchet MS', Arial, sans-serif),
-      font-weight: 700,
-      font-style: normal
-    ),
-    helvetica: (
-      font-family: ('Helvetica Neue', Helvetica, Arial, sans-serif;),
-      font-weight: normal,
-      font-style: normal
-    )
-  );
-
-  $type-styles: (
-    heading: (
-      stack: futura-bold,
-      line-height: 1,
-      text-transform: normal,
-      letter-spacing: 0,
-      sizes: (
-        default: 14
-      )
-    ),
-
-    body: (
-      stack: helvetica,
-      line-height: 1.4,
-      text-transform: uppercase,
-      letter-spacing: 1.2,
-      font-smoothing: true,
-      sizes: (
-        default: 16,
-        medium: 24
-      )
-    )
-  );
 */
+
+$font-stacks: (
+  futura-bold: (
+    font-family: (Futura, 'Trebuchet MS', Arial, sans-serif),
+    font-weight: 700,
+    font-style: normal
+  ),
+  helvetica: (
+    font-family: ('Helvetica Neue', Helvetica, Arial, sans-serif),
+    font-weight: normal,
+    font-style: normal
+  )
+) !default;
+
+$type-styles: (
+  heading: (
+    stack: futura-bold,
+    line-height: 1,
+    text-transform: normal,
+    letter-spacing: 0,
+    sizes: (
+      default: 14
+    )
+  ),
+
+  body: (
+    stack: helvetica,
+    line-height: 1.4,
+    text-transform: uppercase,
+    letter-spacing: 1.2,
+    font-smoothing: true,
+    sizes: (
+      default: 16,
+      medium: 24
+    )
+  )
+) !default;
 
 
 //---------------------------------------------------------------

--- a/_type-styles.scss
+++ b/_type-styles.scss
@@ -10,12 +10,12 @@
 */
 
 $font-stacks: (
-  futura-bold: (
-    font-family: (Futura, 'Trebuchet MS', Arial, sans-serif),
+  serif: (
+    font-family: (Georgia, Times, "Times New Roman", serif),
     font-weight: 700,
     font-style: normal
   ),
-  helvetica: (
+  sans-serif: (
     font-family: ('Helvetica Neue', Helvetica, Arial, sans-serif),
     font-weight: normal,
     font-style: normal
@@ -24,24 +24,23 @@ $font-stacks: (
 
 $type-styles: (
   heading: (
-    stack: futura-bold,
-    line-height: 1,
+    stack: sans-serif,
+    line-height: 1.4,
     text-transform: normal,
     letter-spacing: 0,
     sizes: (
-      default: 14
+      default: 24,
+      medium: 36
     )
   ),
 
   body: (
-    stack: helvetica,
-    line-height: 1.4,
-    text-transform: uppercase,
-    letter-spacing: 1.2,
-    font-smoothing: true,
+    stack: serif,
+    line-height: 1.6,
+    text-transform: normal,
+    letter-spacing: 0,
     sizes: (
-      default: 16,
-      medium: 24
+      default: 16
     )
   )
 ) !default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-sass-toolkit",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A collection of foundational utilities for Sass",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This uncomments our structure examples and adds them as defaults. This way you can use the mixins out of the box (even though they won't be what you want). It also means you can define your own variables _after_ these are declared. 

In other words you can do:
```
@import 'one-sass-toolkit/spacing'
@import 'your-variables'
```