### PR TITLE
Adds mixin making it possible to grab a type style without the responsive adjustments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Automatically generates all of the type styles for a project, provides a mixin f
 
 #### As an SCSS mixin
 
+### With responsive sizing
+
 ```scss
 .my-heading {
   @include type-style(heading);
@@ -115,6 +117,48 @@ Automatically generates all of the type styles for a project, provides a mixin f
   .my-heading {
       font-size: 1.8rem;
   }
+}
+*/
+```
+
+### Without responsive sizing
+
+If you'd like to get a type style at a specific size, without automatically including the responsive adjustments, you can use the `get-type-style` mixin:
+
+```scss
+.my-heading {
+    @include get-type-style(heading, medium);
+}
+
+// Outputs the following css
+
+/*
+.my-heading {
+  font-family: Futura, 'Trebuchet MS', Arial, sans-serif,
+  font-size: 1.8rem,
+  line-height: 1,
+  text-transform: normal,
+  letter-spacing: 0
+}
+*/
+```
+
+### Font stack only
+
+And if you _only_ want the basic styling for a font stack, you can use the `font-stack-styles` mixin:
+
+```scss
+.my-heading {
+    @include font-stack-styles(futura-bold);
+}
+
+// Outputs the following css
+
+/*
+.my-heading {
+  font-family: (Futura, 'Trebuchet MS', Arial, sans-serif),
+  font-weight: 700,
+  font-style: normal
 }
 */
 ```

--- a/_font-smoothing.scss
+++ b/_font-smoothing.scss
@@ -1,0 +1,12 @@
+//===============================================================
+// Font Smoothing
+//===============================================================
+/*
+  Adjust font smoothing for improved rendering when light text is on top of dark backgrounds.
+*/
+
+
+@mixin font-smoothing() {
+  -moz-osx-font-smoothing: grayscale; 
+  -webkit-font-smoothing: antialiased;
+}

--- a/_type-styles.scss
+++ b/_type-styles.scss
@@ -1,4 +1,5 @@
 @import "map-deep-get";
+@import "font-smoothing";
 @import "node_modules/sass-mq/mq";
 
 //===============================================================
@@ -81,36 +82,51 @@ $type-styles: (
 
 
 //---------------------------------------------------------------
+// Get Type Style
+//---------------------------------------------------------------
+/*
+  Mixin for getting a font-stack and size from the $type-styles map.
+  @param $key (string)  - Should be a top level key from the $type-styles map
+  @param $size (string) - The size key to grab, should correspond to a breakpoint
+  @param $map (map)     - Map to search for $key [$font-stacks]  
+*/
+@mixin get-type-style($key, $size: default, $map: $type-styles) {
+  @if map-has-key($map, $key){
+    // Get the style map from within our $type-styles map
+    $map-style: get-style-map($key, $map);
+    // Use $key to get the 'sizes' map from within the styles map
+    $map-sizes: map-deep-get($map, $key, 'sizes');
+    // Get the  size from that size map
+    $font-size: map-get($map-sizes, $size);
+
+    // Set font-size
+    font-size: ($font-size / 10) * 1rem;
+    line-height: map-get($map-style, line-height);
+    text-transform: map-get($map-style, text-transform);
+    letter-spacing: map-get($map-style, letter-spacing);
+    @if map_has_key($map, $key) and map-get($map-style, font-smoothing)  {
+      @include font-smoothing();
+    }
+    // Set font-family
+    @include font-stack-styles(map-get($map-style, 'stack'));
+  }
+}
+
+
+
+//---------------------------------------------------------------
 // Type Styles
 //---------------------------------------------------------------
 /*
-  Generate font-family and typesize styles across breakpoints.
+  Generate font-family and typesize styles across breakpoints. 
   @param $key (string)   - Should be a top level key from the $type-styles map
-  @param $map (map)      - Map to search for $key [$font-stacks]
+  @param $map (map)      - Map to search for $key [$font-stacks] 
 */
 @mixin type-style($key, $map: $type-styles) {
-  // Get the style map from within our $type-styles map
-  $map-style: get-style-map($key, $map);
+  @include get-type-style($key, default);
 
   // Use $key to get the 'sizes' map from within the styles map
   $map-sizes: map-deep-get($map, $key, 'sizes');
-
-  // Get the default size from that size map
-  $default: map-get($map-sizes, default);
-
-  // Set base font-size
-  font-size: ($default / 10) * 1rem;
-  line-height: map-get($map-style, line-height);
-  text-transform: map-get($map-style, text-transform);
-  letter-spacing: map-get($map-style, letter-spacing);
-  @if map_has_key($map, $key) and map-get($map-style, font-smoothing)  {
-    @include font-smoothing();
-  }
-
-  // Set font-family
-  @include font-stack-styles(map-get($map-style, 'stack'));
-
-  // Remove the default size from the map before generating mq-based font-sizes
   $responsive-sizes: map-remove($map-sizes, default);
 
   @each $break, $size in $responsive-sizes {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-sass-toolkit",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A collection of foundational utilities for Sass",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   "license": "MIT",
   "homepage": "https://github.com/onedesign/one-sass-toolkit",
   "dependencies": {
-    "sass-mq": "^3.2.9"
+    "sass-mq": "^3.3.2"
   }
 }


### PR DESCRIPTION
On Freeman, we found it was occasionally necessary to get a type style _without_ including all of the automatic responsive code that comes with mixin `type-style`. Kinda like the relation ship between the `spacing` mixin and the `get-spacing` mixin. We added it on that project with the eventual goal of folding those changes into this repo.

That's what this PR does.

Doesn't change any existing APIs, so only bumped the minor version number.