### PR TITLE
Changes type style config to accept arbitrary properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $colors: (
 
 ### Type Styles
 
-Automatically generates all of the type styles for a project, provides a mixin for grabbing a specific set of predefined styles, adjusts type responsively, and provides optional helper classes for your type styles that can be used directly in your HTML.
+Automatically generates all of the type styles for a project, provides a mixin for grabbing a specific set of predefined styles, adjusts type responsively, and provides optional helper classes for your type styles that can be used directly in your HTML. A type style can be any collection of CSS properties. Anything you add to the `properties` key of the configuration map will be output by the mixin.
 
 #### As an SCSS mixin
 
@@ -192,24 +192,28 @@ $font-stacks: (
 $type-styles: (
   heading: (
     stack: futura-bold,
-    line-height: 1,
-    text-transform: normal,
-    letter-spacing: 0,
     sizes: (
       default: 14,
       medium: 18
+    ),
+    properties: (
+      line-height: 1,
+      text-transform: normal,
+      letter-spacing: 0,
     )
   ),
 
   body: (
     stack: helvetica,
-    line-height: 1.4,
-    text-transform: uppercase,
-    letter-spacing: 1.2,
     font-smoothing: true,
     sizes: (
       default: 16,
       medium: 24
+    ),
+    properties: (
+      line-height: 1.4,
+      text-transform: uppercase,
+      letter-spacing: 1.2,
     )
   )
 );

--- a/_type-styles.scss
+++ b/_type-styles.scss
@@ -26,22 +26,22 @@ $font-stacks: (
 $type-styles: (
   heading: (
     stack: sans-serif,
-    line-height: 1.4,
-    text-transform: normal,
-    letter-spacing: 0,
     sizes: (
       default: 24,
       medium: 36
+    ),
+    properties: (
+      line-height: 1.4,
     )
   ),
 
   body: (
     stack: serif,
-    line-height: 1.6,
-    text-transform: normal,
-    letter-spacing: 0,
     sizes: (
       default: 16
+    ),
+    properties: (
+      line-height: 1.6,
     )
   )
 ) !default;
@@ -88,7 +88,7 @@ $type-styles: (
   Mixin for getting a font-stack and size from the $type-styles map.
   @param $key (string)  - Should be a top level key from the $type-styles map
   @param $size (string) - The size key to grab, should correspond to a breakpoint
-  @param $map (map)     - Map to search for $key [$font-stacks]  
+  @param $map (map)     - Map to search for $key [$font-stacks]
 */
 @mixin get-type-style($key, $size: default, $map: $type-styles) {
   @if map-has-key($map, $key){
@@ -101,14 +101,19 @@ $type-styles: (
 
     // Set font-size
     font-size: ($font-size / 10) * 1rem;
-    line-height: map-get($map-style, line-height);
-    text-transform: map-get($map-style, text-transform);
-    letter-spacing: map-get($map-style, letter-spacing);
+
     @if map_has_key($map, $key) and map-get($map-style, font-smoothing)  {
       @include font-smoothing();
     }
     // Set font-family
     @include font-stack-styles(map-get($map-style, 'stack'));
+
+    // Set arbitrary properties
+    @if map_has_key($map-style, 'properties') {
+      @each $property, $value in map-get($map-style, 'properties') {
+        #{$property}: $value;
+      }
+    }
   }
 }
 
@@ -118,9 +123,9 @@ $type-styles: (
 // Type Styles
 //---------------------------------------------------------------
 /*
-  Generate font-family and typesize styles across breakpoints. 
+  Generate font-family and typesize styles across breakpoints.
   @param $key (string)   - Should be a top level key from the $type-styles map
-  @param $map (map)      - Map to search for $key [$font-stacks] 
+  @param $map (map)      - Map to search for $key [$font-stacks]
 */
 @mixin type-style($key, $map: $type-styles) {
   @include get-type-style($key, default);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-sass-toolkit",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "A collection of foundational utilities for Sass",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Continued from #10, this is _just_ the arbitrary properties part of that PR. 

This changes the idea of a type style from a collection of `line-height`, `text-transform` and `letter-spacing` to a collection of any CSS properties. This should allow our type styles to be quite a bit more flexible, and hopefully easier to use.