### PR TITLE
Simplifies font-family map

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,21 +177,13 @@ Also relies on $`type-styles` and `$font-stacks` map variables existing in the f
 
 ```scss
 $font-stacks: (
-  futura-bold: (
-    font-family: (Futura, 'Trebuchet MS', Arial, sans-serif),
-    font-weight: 700,
-    font-style: normal
-  ),
-  helvetica: (
-    font-family: ('Helvetica Neue', Helvetica, Arial, sans-serif;),
-    font-weight: normal,
-    font-style: normal
-  )
+  futura: (Futura, 'Trebuchet MS', Arial, sans-serif),
+  helvetica: ('Helvetica Neue', Helvetica, Arial, sans-serif)
 );
 
 $type-styles: (
   heading: (
-    stack: futura-bold,
+    stack: futura,
     sizes: (
       default: 14,
       medium: 18

--- a/_type-styles.scss
+++ b/_type-styles.scss
@@ -11,16 +11,8 @@
 */
 
 $font-stacks: (
-  serif: (
-    font-family: (Georgia, Times, "Times New Roman", serif),
-    font-weight: 700,
-    font-style: normal
-  ),
-  sans-serif: (
-    font-family: ('Helvetica Neue', Helvetica, Arial, sans-serif),
-    font-weight: normal,
-    font-style: normal
-  )
+  serif: (Georgia, Times, "Times New Roman", serif),
+  sans-serif: ('Helvetica Neue', Helvetica, Arial, sans-serif),
 ) !default;
 
 $type-styles: (
@@ -63,24 +55,6 @@ $type-styles: (
   }
 }
 
-
-//---------------------------------------------------------------
-// Font Stack Styles
-//---------------------------------------------------------------
-/*
-  Generates font styles related to a specific font-stack.
-  @param $key (string)  - Key to find in $map
-  @param $map (map)     - Map to search for $key [$font-stacks]
-*/
-@mixin font-stack-styles($key, $map: $font-stacks) {
-  @if map_has_key($map, $key) {
-    font-family: map-deep-get($map, $key, 'font-family');
-    font-weight: map-deep-get($map, $key, 'font-weight');
-    font-style: map-deep-get($map, $key, 'font-style');
-  }
-}
-
-
 //---------------------------------------------------------------
 // Get Type Style
 //---------------------------------------------------------------
@@ -102,11 +76,12 @@ $type-styles: (
     // Set font-size
     font-size: ($font-size / 10) * 1rem;
 
-    @if map_has_key($map, $key) and map-get($map-style, font-smoothing)  {
+    @if map_has_key($map, $key) and map-get($map-style, font-smoothing) {
       @include font-smoothing();
     }
     // Set font-family
-    @include font-stack-styles(map-get($map-style, 'stack'));
+    $family-key: map-get($map-style, 'stack');
+    font-family: map-get($font-stacks, $family-key);
 
     // Set arbitrary properties
     @if map_has_key($map-style, 'properties') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-sass-toolkit",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A collection of foundational utilities for Sass",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Switches up the font family map to exclude `font-weight`, and `font-style` in favor of setting those during the `@font-face` declaration.