### PR TITLE
Feature/Fluid sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A collection of foundational utilities for Sass.
 
 - [Color](#color)
 - [Type Styles](#type-styles)
-- [Spacing](#spacing)
-- [Fluid Type](#fluid-type)
+- [Fluid Size](#fluid-size)
+- [Fluid](#fluid)
 
 ## Install
 
@@ -18,9 +18,9 @@ npm install one-sass-toolkit --save
 ```scss
 // in your main.scss
 @import "one-sass-toolkit/color";
-@import "one-sass-toolkit/spacing";
 @import "one-sass-toolkit/type-styles";
-@import "one-sass-toolkit/fluid-type";
+@import "one-sass-toolkit/fluid-size";
+@import "one-sass-toolkit/fluid";
 ```
 
 ## Use
@@ -36,6 +36,7 @@ There are three variables included for outputting helpers. One for each toolkit 
 $output-color-helpers
 $output-spacing-helpers
 $output-type-helpers
+$output-fluid-size-helpers
 ```
 
 By default all helpers are output, to turn them off just add the variable and set the variable to `false`.
@@ -219,7 +220,78 @@ $type-styles: (
 );
 ```
 
+### Fluid Size
+
+The fluid size mixin makes it simple to smoothly adjust a value across a range of breakpoints, with precise control over the value at each breakpoint. It’s great for handling responsive margins and padding, but can be used for any numeric value, including font sizes, absolute/relative positioning values, etc. Interally, this mixin extends the `fluid` mixin mentioned later on. If you want a simpler, lower-level way to handle fluid property adjustments, check out the `fluid` mixin.
+
+#### Required Setup
+
+Relies on a `$fluid-sizes` map variable existing in the following format:
+
+```scss
+$fluid-sizes: (
+  s: (
+    default: 20px,
+    medium: 40px,
+    max: 80px
+  ),
+
+  m: (
+    default: 20px,
+    medium: 60px,
+    max: 100px
+  )
+);
+```
+
+Each set in `$fluid-sizes` can have any key (e.g. `s`) and _must_ include at least a `default` key/value and one other key/value pair representing another breakpoint. Each key/value pair inside of a set should have a key that matches a value from you `$mq-breakpoints` map, and a value that matches the desired value when the viewport width is at that breakpoint.
+
+The `default` key here represents the minimum possible size/value, as defined by the `$fluid-min-width` variable, which is `320px` by default. You can adjust this value by setting a `$fluid-min-width` variable to the smallest possible viewport width you want to handle.
+
+#### As a mixin
+
+```scss
+* + * {
+  @include fluid-size(s); // by default, the value is applied to `margin-top`
+}
+
+* + * {
+  @include fluid-size(m, padding-bottom); // applies the value to any property
+}
+```
+
+When applied using the `$fluid-sizes` map in the example above, the first example here would output a `margin-top` value of `20px` at a viewport width of `320px` wide, which would scale up to a value of `40px` at the `medium` breakpoint, then scale up to a maximum value of `80px` at the `max` breakpoint. The value will never be less than `20px` and never more than `80px`
+
+#### With negative values
+
+You can adjust the mixin to produce negative values from any `$fluid-sizes` set by setting the `$negative` parameter to true:
+
+```scss
+* + * {
+  @include fluid-size(s, margin-top, $negative: true);
+}
+```
+
+#### A note about units
+
+Due to some browser inconsistencies when using the CSS `calc()` function that is used by this mixin behind the scenes, we recommend setting all `$fluid-sizes` values in `px`, and all values _must_ include a unit, even `0` values (i.e. use `0px` instead of `0`). Failing to follow these guidelines probably wont’t cause issues in all browsers, but cross-browser behavior may be inconsistent.
+
+#### As an HTML class
+
+Works for any of the following classes:
+
+- `h-fluid-size-top-margin-{$amount}`
+- `h-fluid-size-bottom-margin-{$amount}`
+- `h-fluid-size-top-padding-{$amount}`
+- `h-fluid-size-bottom-padding-{$amount}`
+
+```html
+<h1 class="h-fluid-size-top-margin-s">Ground control to Major Tom</h1>
+```
+
 ### Spacing
+
+**Deprecated and may be removed in a future release. Use `fluid-size` instead.**
 
 Mixin to provide spacing (either margin or padding) to a defined
 location of an element and have that spacing scale down proportionally
@@ -279,19 +351,21 @@ $spacing: (
 
 The exact names of the keys in this map aren't important, as long as `@include spacing(foo)` has a matching key `foo` in the map.
 
-### Fluid Type
-Written by [Indrek Paas](https://github.com/indrekpaas) and inspired by [Mike Riethmuller](https://madebymike.com.au/writing/precise-control-responsive-typography/) this mixin allows you to specify a minumum and maximum size for values. Allowing for more fluid websites.
+### Fluid
+
+Inspired by the work of [Indrek Paas](https://github.com/indrekpaas) and the writing of [Mike Riethmuller](https://madebymike.com.au/writing/precise-control-responsive-typography/) this mixin allows you to specify a minumum and maximum size for values. Allowing for more fluid websites.
 
 #### As an SCSS mixin
+
 ```scss
-@include fluid-type($properties)
+@include fluid($properties)
 /* Single property */
 html {
-  @include fluid-type(font-size, 320px, 1366px, 14px, 18px);
+  @include fluid(font-size, 320px, 1366px, 14px, 18px);
 }
 
 /* Multiple properties with same values */
 h1 {
-  @include fluid-type(padding-bottom padding-top, 20em, 70em, 2em, 4em);
+  @include fluid(padding-bottom padding-top, 20em, 70em, 2em, 4em);
 }
 ```

--- a/_fluid-size.scss
+++ b/_fluid-size.scss
@@ -1,0 +1,123 @@
+@import "fluid";
+
+//===============================================================
+// Fluid Size
+//===============================================================
+/*
+  Mixin to provide sizing (often either margin or padding, but can be any numeric property) to a defined
+  location of an element and have that spacing scale fluidly between screen sizes.
+  Relies on a $fluid-sizes map variable existing in the following format:
+*/
+
+$fluid-sizes: (
+  s: (
+    default: 20px,
+    medium: 40px,
+    max: 80px
+  ),
+
+  m: (
+    default: 20px,
+    medium: 40px,
+    max: 80px
+  )
+) !default;
+
+$fluid-min-width: 320px !default;
+
+
+//---------------------------------------------------------------
+// Get Fluid Size
+//---------------------------------------------------------------
+/*
+  Function for getting a specific size/breakpoint value from the $fluid-sizes map.
+  @param $size (string)           - Key size you want
+  @param $breakpoint (string)     - The breakpoint you want sizing at
+*/
+@function get-fluid-size($size, $breakpoint: null) {
+  @if map-has-key($fluid-sizes, $size) {
+    $size-set: map-get($fluid-sizes, $size);
+    @if map-has-key($size-set, $breakpoint) {
+      @return map-get($size-set, $breakpoint);
+    } @else {
+      $breakpoints-length: length(map-values($size-set));
+      $last-breakpoint-value: nth(map-values($size-set), $breakpoints-length);
+      @return $last-breakpoint-value;
+    }
+  }
+}
+
+
+//---------------------------------------------------------------
+// Get Size Set
+//---------------------------------------------------------------
+/*
+  Function for getting a specific size set from the $fluid-sizes map.
+  @param $size (string)  - Size set you want
+*/
+@function get-spacing-size($size) {
+  @if map-has-key($fluid-sizes, $size) {
+    @return map-get($fluid-sizes, $size);
+  }
+}
+
+
+//---------------------------------------------------------------
+// Output Size Markup
+//---------------------------------------------------------------
+/*
+  Generates fluid size and applies it to the supplied property.
+  @param $size (key)                   - Key size you want (from the $fluid-sizes map)
+  @param $property (string)            - The css property you'd like to apply the size to
+                                         will only be applied up until this breakpoint.
+  @param $negative (boolean)           - If true, returns a negative range
+*/
+@mixin fluid-size($size, $property: margin-top, $negative: false) {
+  @if map-has-key($fluid-sizes, $size) {
+    // Set size value
+    $size-set: get-spacing-size($size);
+
+    // Set initial breakpoint
+    $previous-breakpoint: $fluid-min-width;
+    $previous-size: map-get($size-set, default);
+
+    @each $key, $value in $size-set {
+      @if map-has-key($mq-breakpoints, $key) {
+        $new-breakpoint: map-get($mq-breakpoints, $key);
+        @include fluid($property, $previous-breakpoint, $new-breakpoint, $previous-size, $value, $negative);
+        $previous-breakpoint: $new-breakpoint;
+        $previous-size: $value;
+      }
+    }
+  }
+}
+
+//---------------------------------------------------------------
+// Output Helper Classes
+//---------------------------------------------------------------
+/*
+  Loop through the $fluid-sizes map (defined in `_base/variables.scss`)
+  and generate helpers classes we can use to apply directly into our
+  template markup.
+*/
+
+$output-fluid-size-helpers: true !default;
+
+@if $output-fluid-size-helpers {
+  @each $amount in map-keys($fluid-sizes) {
+    .h-fluid-size-top-margin-#{$amount} {
+      @include fluid-size($amount);
+    }
+    .h-fluid-size-bottom-margin-#{$amount} {
+      @include fluid-size($amount, margin-bottom);
+    }
+
+    .h-fluid-size-top-padding-#{$amount} {
+      @include fluid-size($amount, padding-top);
+    }
+
+    .h-fluid-size-bottom-padding-#{$amount} {
+      @include fluid-size($amount, padding-bottom);
+    }
+  }
+}

--- a/_fluid.scss
+++ b/_fluid.scss
@@ -1,8 +1,8 @@
-@import "strip-unit";
+@import "strip-units";
 
 // =========================================================================
 //
-//  PRECISE CONTROL OVER RESPONSIVE TYPOGRAPHY FOR SASS
+//  PRECISE CONTROL OVER RESPONSIVE SIZING FOR SASS
 //  ---------------------------------------------------
 //  Indrek Paas @indrekpaas
 //
@@ -16,15 +16,21 @@
 /// @param {string} $max-vw - maximum viewport width for values
 /// @param {string} $min-value - minimum value
 /// @param {string} $max-value - maximum value
+/// @param {boolean} $negative - whether the value range should be negative
 
-@mixin fluid-type($properties, $min-vw, $max-vw, $min-value, $max-value) {
+@mixin fluid($properties, $min-vw, $max-vw, $min-value, $max-value, $negative: false) {
+  @if $negative {
+    $min-value: $min-value * -1;
+    $max-value: $max-value * -1;
+  }
+
   @each $property in $properties {
     #{$property}: $min-value;
   }
 
   @media screen and (min-width: $min-vw) {
     @each $property in $properties {
-      #{$property}: calc(#{$min-value} + #{strip-unit($max-value - $min-value)} * (100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)});
+      #{$property}: calc(#{$min-value} + #{strip-units($max-value - $min-value)} * ((100vw - #{$min-vw}) / #{strip-units($max-vw - $min-vw)}));
     }
   }
 

--- a/_spacing.scss
+++ b/_spacing.scss
@@ -50,6 +50,8 @@ $spacing: (
                                          will only be applied up until this breakpoint.
 */
 @mixin spacing($size, $property: margin-top, $negative: false,  $sizeAdjustSmall: 0.7, $sizeAdjustMedium: 0.85, $until: false) {
+  @warn "The one-sass-toolkit `spacing()` mixin is deprecated and may be removed in a future release. Consider using the `fluid-size()` mixin instead.";
+
   @if map-has-key($spacing, $size) {
 
     // Set spacing value

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-sass-toolkit",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A collection of foundational utilities for Sass",
   "repository": {
     "type": "git",


### PR DESCRIPTION
For the last four projects I’ve worked on I've been using a new methodology and mixin for setting fluid spacing values, in place of the current `spacing()` mixin. This new mixin makes it super easy to adjust values fluidly across breakpoints, with precise control at where those values will fall at different breakpoints.

I would personally be okay with eliminating the current `spacing()` mixin altogether, since I think this method is better in every way, but instead I've just deprecated it in this PR: it's marked as deprecated in the README and Sass will output a deprecation warning in the console when the `spacing()` mixin is used.

Resolves #14 