### PR TITLE
Updates references to strip-unit() function.

### DIFF
--- a/_fluid.scss
+++ b/_fluid.scss
@@ -1,4 +1,4 @@
-@import "strip-units";
+@import "strip-unit";
 
 // =========================================================================
 //
@@ -30,7 +30,7 @@
 
   @media screen and (min-width: $min-vw) {
     @each $property in $properties {
-      #{$property}: calc(#{$min-value} + #{strip-units($max-value - $min-value)} * ((100vw - #{$min-vw}) / #{strip-units($max-vw - $min-vw)}));
+      #{$property}: calc(#{$min-value} + #{strip-unit($max-value - $min-value)} * ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)}));
     }
   }
 

--- a/_strip-unit.scss
+++ b/_strip-unit.scss
@@ -1,11 +1,13 @@
-/// Remove the unit of a length
-/// https://css-tricks.com/snippets/sass/strip-unit-function/
-/// @param {Number} $number - Number to remove unit from
-/// @return {Number} - Unitless number
-@function strip-unit($number) {
-  @if type-of($number) == 'number' and not unitless($number) {
-    @return $number / ($number * 0 + 1);
-  }
+// ===============================================================
+// Strip Unit
+// ===============================================================
+/*
+  Strips the unit from a value. e.g. 12px -> 12
+  
+  @param  {String} $val      - Value to remove unit from
+  @return {Number}           - Unitless number
+*/
 
-  @return $number;
+@function strip-unit($val) {
+  @return ($val / ($val * 0 + 1));
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-sass-toolkit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A collection of foundational utilities for Sass",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `fluid-type()` mixin only worked before because the generator includes a `strip-units()` mixin by default. But if that get's removed this stuff will break. We should probably update/remove that mixin in the generator as well, but this at least fixes it for `one-sass-toolkit`