### PR TITLE
 Allows @fluid-size and @fluid to take adjustment values that will be added to the fluid amount.

### DIFF
--- a/_fluid-size.scss
+++ b/_fluid-size.scss
@@ -72,7 +72,7 @@ $fluid-min-width: 320px !default;
                                          will only be applied up until this breakpoint.
   @param $negative (boolean)           - If true, returns a negative range
 */
-@mixin fluid-size($size, $property: margin-top, $negative: false) {
+@mixin fluid-size($size, $property: margin-top, $negative: false, $adjust: 0) {
   @if map-has-key($fluid-sizes, $size) {
     // Set size value
     $size-set: get-spacing-size($size);
@@ -84,7 +84,7 @@ $fluid-min-width: 320px !default;
     @each $key, $value in $size-set {
       @if map-has-key($mq-breakpoints, $key) {
         $new-breakpoint: map-get($mq-breakpoints, $key);
-        @include fluid($property, $previous-breakpoint, $new-breakpoint, $previous-size, $value, $negative);
+        @include fluid($property, $previous-breakpoint, $new-breakpoint, $previous-size, $value, $negative, $adjust);
         $previous-breakpoint: $new-breakpoint;
         $previous-size: $value;
       }

--- a/_fluid.scss
+++ b/_fluid.scss
@@ -18,25 +18,27 @@
 /// @param {string} $max-value - maximum value
 /// @param {boolean} $negative - whether the value range should be negative
 
-@mixin fluid($properties, $min-vw, $max-vw, $min-value, $max-value, $negative: false) {
+@mixin fluid($properties, $min-vw, $max-vw, $min-value, $max-value, $negative: false, $adjust: 0) {
   @if $negative {
-    $min-value: $min-value * -1;
-    $max-value: $max-value * -1;
+    $min-value: ($min-value + $adjust) * -1;
+    $max-value: ($max-value + $adjust) * -1;
   }
 
   @each $property in $properties {
-    #{$property}: $min-value;
+    #{$property}: $min-value + $adjust;
   }
 
   @media screen and (min-width: $min-vw) {
     @each $property in $properties {
+      $min-value: $min-value + $adjust;
+      $max-value: $max-value + $adjust;
       #{$property}: calc(#{$min-value} + #{strip-unit($max-value - $min-value)} * ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)}));
     }
   }
 
   @media screen and (min-width: $max-vw) {
     @each $property in $properties {
-      #{$property}: $max-value;
+      #{$property}: $max-value + $adjust;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-sass-toolkit",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A collection of foundational utilities for Sass",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This can be really useful if you're doing something like the following, which I do all the time:

```css
.MyLayout {
  > * + * {
    @include fluid-size(m, margin-top);
  }

  // Custom spacing for certain elements
  > .text + .list {
    @include fluid-size(m, margin-top, $adjust: 5px);
  }
}
```

Allows you to still have a base amount of space that is fluid and consistent, but tweak that amount slightly for certain elements. This is a non-breaking change for existing code using one-sass-toolkit.